### PR TITLE
Fix SearchControllerにおけるお気に入り順でのバグ修正

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -54,7 +54,7 @@ class SearchController < ApplicationController
   case params[:sort_by]
   when '0'
     @data = @data.joins(:favorites)
-    .group("posts.id")
+    .group("posts.post_id")
     .order("COUNT(favorites.post_id) DESC")
   when '1'
     @data = @data.order(number_of_men: sort_direction)


### PR DESCRIPTION
お気に入り順でのpost.idがpost_idでなければならないので修正しました。